### PR TITLE
Change title bar style to 'hidden-inset' on OSX

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -191,3 +191,11 @@ a[href^="ftp://"] {
         margin-top: .2rem;
     }
 }
+
+.navmain {
+    -webkit-app-region: drag;
+}
+
+.mac-inset {
+    padding-left: 70px;
+}

--- a/main.js
+++ b/main.js
@@ -79,16 +79,15 @@ if (fs.existsSync(targetPath)){
 
 function createWindow () {
   // Create the browser window.
-  mainWindow = new BrowserWindow(
-	{
+  mainWindow = new BrowserWindow({
+    titleBarStyle: 'hidden-inset',
 	  width: 900, 
 	  height: 700, 
 	  minWidth: 760, 
 	  minHeight: 480,
 	  icon: __dirname + '/img/icon.png',
 	  backgroundColor: '#2b3e50'
-	}
-  )
+	})
 
   // and load the index.html of the app.
   mainWindow.loadURL(url.format({
@@ -112,7 +111,7 @@ function createWindow () {
   if (process.platform == 'win32') {
     // Keep only command line / deep linked arguments
     deeplinkingUrl = process.argv.slice(1)
-  }
+	}
 	
 	openDeepLinking(deeplinkingUrl,1);
 }

--- a/renderer-index.js
+++ b/renderer-index.js
@@ -220,6 +220,11 @@ function checkNewVersion() {
 	});
 }
 
+// [YB]: Add a slight padding to navbar on OSX:
+if (process.platform === 'darwin') {
+  $('.navmain').addClass('mac-inset');
+}
+
 $('#config-button').on('click', function() {
 	let showRegion = store.get('region');
 	let basePath = store.get('baseDirectory');


### PR DESCRIPTION
I also added a bit of padding for navbar, but only in OSX, so inset title buttons look good. The title bar is also draggable now. Please see screenshots from macOS and Windows:

<img width="1012" alt="2017-11-30 15 40 38" src="https://user-images.githubusercontent.com/908865/33431572-ea3c6d3a-d5e5-11e7-82d4-262e5bb51296.png">
<img width="891" alt="2017-11-30 15 40 22" src="https://user-images.githubusercontent.com/908865/33431577-ed85daee-d5e5-11e7-8a6a-05cf86815bb2.png">
